### PR TITLE
Update migration guide in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ pub fn a_standalone_test() {
 If you're coming from [`gleeunit`](https://hexdocs.pm/gleeunit), follow these steps for an easy migration to Startest:
 
 1. Install Startest with `gleam add --dev startest`
+1. Replace all imports of `gleeunit` with `startest`
+1. Replace `gleeunit.main` with `startest.run(startest.default_config())`
 1. Replace all imports of `gleeunit/should` with `startest/expect`
 1. Update `gleeunit/should` assertions to `startest/expect`
    - Consult the migration table down below for the equivalent assertions in Startest


### PR DESCRIPTION
Hi! Here are a couple of small changes to the migrating guide, that may help future migrators:

- Following the steps of the original migrating guide led to a compiler crash.  Moving the `gleam remove gleeunit` step first in the migrating gets around this issue.  (See https://github.com/gleam-lang/gleam/issues/3123 and https://github.com/gleam-lang/gleam/issues/3201)
- Adds steps regarding swapping out `gleeunit.main` for `startest.run`
