### PR TITLE
Add `with_reporters` function

### DIFF
--- a/src/startest/config.gleam
+++ b/src/startest/config.gleam
@@ -25,6 +25,11 @@ pub type Config {
   )
 }
 
+/// Updates the given `Config` with the specified `reporters`.
+pub fn with_reporters(config: Config, reporters: List(Reporter)) -> Config {
+  Config(..config, reporters: reporters)
+}
+
 /// Updates the given `Config` with the specified `discover_describe_tests_pattern`.
 pub fn with_discover_describe_tests_pattern(
   config: Config,


### PR DESCRIPTION
See #4 

I didn't add tests as I didn't see any tests for the other `config.with_*` functions (not that they really need them I suppose).