### PR TITLE
Include skipped count in the reporter statistics

### DIFF
--- a/src/startest/internal/runner/core.gleam
+++ b/src/startest/internal/runner/core.gleam
@@ -85,6 +85,14 @@ pub fn run_tests(test_files: List(TestFile), ctx: Context) {
     clock.now(ctx.clock)
     |> birl.difference(reporting_started_at)
 
+  let skipped_tests =
+    executed_tests
+    |> list.filter(fn(executed_test) {
+      case executed_test.outcome {
+        Skipped -> True
+        Passed | Failed(_) -> False
+      }
+    })
   let failed_tests =
     executed_tests
     |> list.filter_map(fn(executed_test) {
@@ -97,6 +105,7 @@ pub fn run_tests(test_files: List(TestFile), ctx: Context) {
     ctx,
     test_files,
     executed_tests,
+    skipped_tests,
     failed_tests,
     discovery_duration,
     execution_duration,


### PR DESCRIPTION
As per the title. There didn't seem to be any tests since none of them are failing, but I did run it against my own project to take it for a test run:

![image](https://github.com/maxdeviant/startest/assets/336509/e0648815-81ce-49db-94d2-b0fa8b572182)
