### PR TITLE
Update to use gleam_stdlib 0.51.0

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -7,15 +7,16 @@ repository = { type = "github", user = "maxdeviant", repo = "startest" }
 [dependencies]
 argv = ">= 1.0.2 and < 2.0.0"
 bigben = ">= 1.0.0 and < 2.0.0"
-birl = ">= 1.6.1 and < 2.0.0"
+birl = ">= 1.8.0 and < 2.0.0"
 exception = ">= 2.0.0 and < 3.0.0"
-gleam_community_ansi = ">= 1.4.0 and < 2.0.0"
+gleam_community_ansi = ">= 1.4.2 and < 2.0.0"
 gleam_erlang = ">= 0.25.0 and < 1.0.0"
 gleam_javascript = ">= 0.8.0 and < 1.0.0"
-gleam_stdlib = ">= 0.36.0 and < 2.0.0"
-glint = ">= 1.0.0 and < 2.0.0"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
+gleam_stdlib = ">= 0.51.0 and < 1.0.0"
+glint = ">= 1.1.1 and < 2.0.0"
 simplifile = ">= 2.0.0 and < 3.0.0"
 tom = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
-birdie = ">= 1.1.5 and < 2.0.0"
+birdie = ">= 1.2.5 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,26 +4,28 @@
 packages = [
   { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
   { name = "bigben", version = "1.0.0", build_tools = ["gleam"], requirements = ["birl", "gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "bigben", source = "hex", outer_checksum = "8E5A98FA6E981EEEF016C40F1CDFADA095927CAF6CAAA0C7E295EED02FC95947" },
-  { name = "birdie", version = "1.2.4", build_tools = ["gleam"], requirements = ["argv", "edit_distance", "filepath", "glance", "gleam_community_ansi", "gleam_erlang", "gleam_stdlib", "justin", "rank", "simplifile", "trie_again"], otp_app = "birdie", source = "hex", outer_checksum = "769AE13AB5B5B84E724E9966037DCCB5BD63B2F43C52EF80B4BF3351F64E469E" },
-  { name = "birl", version = "1.7.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "5C66647D62BCB11FE327E7A6024907C4A17954EF22865FE0940B54A852446D01" },
+  { name = "birdie", version = "1.2.5", build_tools = ["gleam"], requirements = ["argv", "edit_distance", "filepath", "glance", "gleam_community_ansi", "gleam_erlang", "gleam_stdlib", "justin", "rank", "simplifile", "trie_again"], otp_app = "birdie", source = "hex", outer_checksum = "2531AD6AC71C89DFB7ECC8839C3DAB858963ECA425E9308302D3B93B8AE0FEAD" },
+  { name = "birl", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "2AC7BA26F998E3DFADDB657148BD5DDFE966958AD4D6D6957DD0D22E5B56C400" },
   { name = "edit_distance", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "edit_distance", source = "hex", outer_checksum = "A1E485C69A70210223E46E63985FA1008B8B2DDA9848B7897469171B29020C05" },
   { name = "exception", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "F5580D584F16A20B7FCDCABF9E9BE9A2C1F6AC4F9176FA6DD0B63E3B20D450AA" },
   { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
-  { name = "glance", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "1510D4A03C28880E62974389E5BF1A5A185036BA07392F1D769620706A9E042F" },
-  { name = "gleam_community_ansi", version = "1.4.1", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "4CD513FC62523053E62ED7BAC2F36136EC17D6A8942728250A9A00A15E340E4B" },
+  { name = "glance", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "784CE3B5658CF589B2E811031992FDADDFA9C7FD2A51F1140EE019F121D6D0EB" },
+  { name = "gleam_community_ansi", version = "1.4.2", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "479DEDC748D08B310C9FEB9C4CBEC46B95C874F7F4F2844304D6D20CA78A8BB5" },
   { name = "gleam_community_colour", version = "1.4.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "386CB9B01B33371538672EEA8A6375A0A0ADEF41F17C86DDCB81C92AD00DA610" },
   { name = "gleam_erlang", version = "0.30.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "760618870AE4A497B10C73548E6E44F43B76292A54F0207B3771CBB599C675B4" },
   { name = "gleam_javascript", version = "0.13.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "F98328FCF573DA6F3A35D7F6CB3F9FF19FD5224CCBA9151FCBEAA0B983AF2F58" },
   { name = "gleam_json", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "0A57FB5666E695FD2BEE74C0428A98B0FC11A395D2C7B4CDF5E22C5DD32C74C6" },
   { name = "gleam_otp", version = "0.14.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "5A8CE8DBD01C29403390A7BD5C0A63D26F865C83173CF9708E6E827E53159C65" },
-  { name = "gleam_stdlib", version = "0.43.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "69EF22E78FDCA9097CBE7DF91C05B2A8B5436826D9F66680D879182C0860A747" },
-  { name = "glexer", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "BD477AD657C2B637FEF75F2405FAEFFA533F277A74EF1A5E17B55B1178C228FB" },
-  { name = "glint", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "A3F1B7C665FD216BE6A886D56537F0E095FB07DF62146074109270B798F8CEC4" },
+  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
+  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
+  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "glexer", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "25E87F25706749E40C3CDC72D2E52AEA12260B23D14FD9E09A1B524EF393485E" },
+  { name = "glint", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "5F6720081150AED8023131B0F3A35F9B0D6426A96CE02BEC52AD7018DF70566A" },
   { name = "justin", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "justin", source = "hex", outer_checksum = "7FA0C6DB78640C6DC5FBFD59BF3456009F3F8B485BF6825E97E1EB44E9A1E2CD" },
-  { name = "ranger", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "1566C272B1D141B3BBA38B25CB761EF56E312E79EC0E2DFD4D3C19FB0CC1F98C" },
+  { name = "ranger", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_yielder"], otp_app = "ranger", source = "hex", outer_checksum = "C8988E8F8CDBD3E7F4D8F2E663EF76490390899C2B2885A6432E942495B3E854" },
   { name = "rank", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "rank", source = "hex", outer_checksum = "5660E361F0E49CBB714CC57CC4C89C63415D8986F05B2DA0C719D5642FAD91C9" },
   { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
-  { name = "snag", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "54D32E16E33655346AA3E66CBA7E191DE0A8793D2C05284E3EFB90AD2CE92BCC" },
+  { name = "snag", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "7E9F06390040EB5FAB392CE642771484136F2EC103A92AE11BA898C8167E6E17" },
   { name = "tom", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "228E667239504B57AD05EC3C332C930391592F6C974D0EFECF32FFD0F3629A27" },
   { name = "trie_again", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "trie_again", source = "hex", outer_checksum = "5B19176F52B1BD98831B57FDC97BD1F88C8A403D6D8C63471407E78598E27184" },
 ]
@@ -31,13 +33,14 @@ packages = [
 [requirements]
 argv = { version = ">= 1.0.2 and < 2.0.0" }
 bigben = { version = ">= 1.0.0 and < 2.0.0" }
-birdie = { version = ">= 1.1.5 and < 2.0.0" }
-birl = { version = ">= 1.6.1 and < 2.0.0" }
+birdie = { version = ">= 1.2.5 and < 2.0.0" }
+birl = { version = ">= 1.8.0 and < 2.0.0" }
 exception = { version = ">= 2.0.0 and < 3.0.0" }
-gleam_community_ansi = { version = ">= 1.4.0 and < 2.0.0" }
+gleam_community_ansi = { version = ">= 1.4.2 and < 2.0.0" }
 gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
 gleam_javascript = { version = ">= 0.8.0 and < 1.0.0" }
-gleam_stdlib = { version = ">= 0.36.0 and < 2.0.0" }
-glint = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.51.0 and < 1.0.0" }
+glint = { version = ">= 1.1.1 and < 2.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }
 tom = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/startest.gleam
+++ b/src/startest.gleam
@@ -1,5 +1,5 @@
 import gleam/option.{None}
-import gleam/regex
+import gleam/regexp
 import startest/cli
 import startest/config.{type Config, Config}
 import startest/reporters/default as default_reporter
@@ -38,8 +38,9 @@ pub fn run(config: Config) {
 
 /// Returns the default Startest config.
 pub fn default_config() -> Config {
-  let assert Ok(discover_describe_tests_pattern) = regex.from_string("_tests$")
-  let assert Ok(discover_standalone_tests_pattern) = regex.from_string("_test$")
+  let assert Ok(discover_describe_tests_pattern) = regexp.from_string("_tests$")
+  let assert Ok(discover_standalone_tests_pattern) =
+    regexp.from_string("_test$")
 
   Config(
     reporters: [default_reporter.new()],

--- a/src/startest/config.gleam
+++ b/src/startest/config.gleam
@@ -1,5 +1,5 @@
 import gleam/option.{type Option}
-import gleam/regex.{type Regex}
+import gleam/regexp.{type Regexp}
 import startest/reporters.{type Reporter}
 
 pub type Config {
@@ -10,11 +10,11 @@ pub type Config {
     ///
     /// If a function's name matches the pattern it will be evaluated and expected
     /// to return a `TestTree` (like the ones returned by `describe` or `it`).
-    discover_describe_tests_pattern: Regex,
+    discover_describe_tests_pattern: Regexp,
     /// The pattern to use when discovering tests defined using standalone functions.
     ///
     /// If a function's name matches the pattern it will be run as a test.
-    discover_standalone_tests_pattern: Regex,
+    discover_standalone_tests_pattern: Regexp,
     /// The list of test filepath filters.
     ///
     /// Each filter is matched against a test file's path to determine whether the
@@ -33,7 +33,7 @@ pub fn with_reporters(config: Config, reporters: List(Reporter)) -> Config {
 /// Updates the given `Config` with the specified `discover_describe_tests_pattern`.
 pub fn with_discover_describe_tests_pattern(
   config: Config,
-  discover_describe_tests_pattern: Regex,
+  discover_describe_tests_pattern: Regexp,
 ) -> Config {
   Config(
     ..config,
@@ -44,7 +44,7 @@ pub fn with_discover_describe_tests_pattern(
 /// Updates the given `Config` with the specified `discover_standalone_tests_pattern`.
 pub fn with_discover_standalone_tests_pattern(
   config: Config,
-  discover_standalone_tests_pattern: Regex,
+  discover_standalone_tests_pattern: Regexp,
 ) -> Config {
   Config(
     ..config,

--- a/src/startest/locator.gleam
+++ b/src/startest/locator.gleam
@@ -3,7 +3,7 @@ import birl
 import birl/duration.{type Duration}
 import gleam/dynamic.{type Dynamic}
 import gleam/list
-import gleam/regex
+import gleam/regexp
 import gleam/result.{try}
 import gleam/string
 import simplifile
@@ -147,10 +147,10 @@ fn identify_tests_in_file(
 
 fn is_standalone_test(test_function: TestFunction, ctx: Context) -> Bool {
   test_function.name
-  |> regex.check(with: ctx.config.discover_standalone_tests_pattern)
+  |> regexp.check(with: ctx.config.discover_standalone_tests_pattern)
 }
 
 fn is_test_suite(test_function: TestFunction, ctx: Context) -> Bool {
   test_function.name
-  |> regex.check(with: ctx.config.discover_describe_tests_pattern)
+  |> regexp.check(with: ctx.config.discover_describe_tests_pattern)
 }


### PR DESCRIPTION
I'm running `gleam deps update` in my projects and when going to run `gleam test`, I'm getting errors from `startest`, as the updated local `gleam_stdlib` now no longer has `regex`, which causes `startest` to fail compilation. This PR updates startest to use the latest `gleam_stdlib`.


- Update just enough deps to allow using the latest stdlib (0.51.0).
- Swap to using `gleam_regexp`, as the regex module in the stdlib has been removed.